### PR TITLE
fix: use absolute $HOME paths in home::symlink

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ TODO: Add a short summary of this module.
 
 - `p6df::modules::vim::aliases::init(dir)`
   - Args:
-    - dir - 
+    - dir -
 - `p6df::modules::vim::deps()`
 - `p6df::modules::vim::external::brew()`
 - `p6df::modules::vim::home::symlink()`

--- a/init.zsh
+++ b/init.zsh
@@ -54,8 +54,8 @@ p6df::modules::vim::aliases::init() {
 ######################################################################
 p6df::modules::vim::home::symlink() {
 
-  p6_file_symlink "$P6_DFZ_SRC_P6M7G8_DOTFILES_DIR/p6df-vim/share/vimrc" ".vimrc"
-  p6_file_symlink "$P6_DFZ_SRC_P6M7G8_DOTFILES_DIR/p6df-vim/share/vim" ".vim"
+  p6_file_symlink "$P6_DFZ_SRC_P6M7G8_DOTFILES_DIR/p6df-vim/share/vimrc" "$HOME/.vimrc"
+  p6_file_symlink "$P6_DFZ_SRC_P6M7G8_DOTFILES_DIR/p6df-vim/share/vim" "$HOME/.vim"
 
   p6_return_void
 }


### PR DESCRIPTION
Symlink targets were using relative paths (e.g. `.aws`) instead of absolute `$HOME/.aws`. Fixes symlinks when not run from $HOME.