### PR TITLE
chore(vim): rename home::symlink to home::symlinks, add .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+share/.viminfo

--- a/init.zsh
+++ b/init.zsh
@@ -47,12 +47,12 @@ p6df::modules::vim::aliases::init() {
 ######################################################################
 #<
 #
-# Function: p6df::modules::vim::home::symlink()
+# Function: p6df::modules::vim::home::symlinks()
 #
 #  Environment:	 P6_DFZ_SRC_P6M7G8_DOTFILES_DIR
 #>
 ######################################################################
-p6df::modules::vim::home::symlink() {
+p6df::modules::vim::home::symlinks() {
 
   p6_file_symlink "$P6_DFZ_SRC_P6M7G8_DOTFILES_DIR/p6df-vim/share/vimrc" "$HOME/.vimrc"
   p6_file_symlink "$P6_DFZ_SRC_P6M7G8_DOTFILES_DIR/p6df-vim/share/vim" "$HOME/.vim"


### PR DESCRIPTION
## What
Rename `home::symlink` (singular) to `home::symlinks` (plural). Add .gitignore to exclude viminfo runtime state.

## Why
The p6df-core framework dispatches `home::symlinks` (plural) via `p6df::core::internal::recurse`. The singular function was never auto-called. `share/.viminfo` is runtime state that should not be tracked.

## Test plan
- `p6df home symlinks` recreates ~/.vimrc and ~/.vim
- `git status` shows share/.viminfo ignored

## Dependencies
None