### PR TITLE
fix(prompt): add profile::mod returning p6_return_words for vim

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -37,6 +37,7 @@ p6df::modules::vim::external::brews() {
 #>
 ######################################################################
 p6df::modules::vim::aliases::init() {
+  local _module="$1"
   local dir="$1"
 
   p6_alias "vim" "vim -i $dir/share/.viminfo"
@@ -49,7 +50,7 @@ p6df::modules::vim::aliases::init() {
 #
 # Function: p6df::modules::vim::home::symlinks()
 #
-#  Environment:	 P6_DFZ_SRC_P6M7G8_DOTFILES_DIR
+#  Environment:	 HOME P6_DFZ_SRC_P6M7G8_DOTFILES_DIR
 #>
 ######################################################################
 p6df::modules::vim::home::symlinks() {
@@ -59,3 +60,20 @@ p6df::modules::vim::home::symlinks() {
 
   p6_return_void
 }
+
+######################################################################
+#<
+#
+# Function: words vim $VIMINIT = p6df::modules::vim::profile::mod()
+#
+#  Returns:
+#	words - vim $VIMINIT
+#
+#  Environment:	 VIMINIT
+#>
+######################################################################
+p6df::modules::vim::profile::mod() {
+
+  p6_return_words 'vim' '$VIMINIT'
+}
+

--- a/init.zsh
+++ b/init.zsh
@@ -74,6 +74,6 @@ p6df::modules::vim::home::symlinks() {
 ######################################################################
 p6df::modules::vim::profile::mod() {
 
-  p6_return_words 'vim' '$VIMINIT'
+  p6_return_words 'vim' "$VIMINIT"
 }
 


### PR DESCRIPTION
## What
Refactor prompt module with all local changes including p6_return_words quoting fix.

## Why
Split p6_return_words word and variable into separate quoted args; also includes related prompt/profile refactors.

## Test plan
- Verified diff contains expected changes

## Dependencies
None