### PR TITLE
fix(vim): use single-quoted variables in profile::mod (deferred eval)

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -74,6 +74,6 @@ p6df::modules::vim::home::symlinks() {
 ######################################################################
 p6df::modules::vim::profile::mod() {
 
-  p6_return_words 'vim' "$VIMINIT"
+  p6_return_words 'vim' '$VIMINIT'
 }
 


### PR DESCRIPTION
**What:** Restore single-quoted variables in profile::mod p6_return_words calls

**Why:** Variables are intentionally single-quoted; eval happens later via p6_return_words machinery. The SC2016 fix incorrectly expanded them at call time.

**Test plan:** Build CI passes

**Dependencies:** None